### PR TITLE
Make sure Channel identifier remains the same for same parameters

### DIFF
--- a/ActionCableClient.podspec
+++ b/ActionCableClient.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "ActionCableClient"
-  s.version          = "0.3.2"
+  s.version          = "0.3.3"
   s.summary          = "A Swift client for the Rails ActionCable WebSocket server."
   s.description      = <<-DESC
   ActionCable is a new WebSocket server being released with Rails 5 which makes it easy to add real-time features to your app. This Swift client makes it dead-simple to connect with that server, abstracting away everything except what you need to get going.

--- a/Source/Classes/Channel.swift
+++ b/Source/Classes/Channel.swift
@@ -100,7 +100,7 @@ open class Channel: Hashable, Equatable {
         identifierDict["channel"] = name
 
         // If something is wrong with the parameters, the developer will be warn with a runtime exception.
-        let JSONData = try! JSONSerialization.data(withJSONObject: identifierDict, options: JSONSerialization.WritingOptions(rawValue: 0))
+        let JSONData = try! JSONSerialization.data(withJSONObject: identifierDict, options: [.sortedKeys])
         return NSString(data: JSONData, encoding: String.Encoding.utf8.rawValue)! as String
     }
 


### PR DESCRIPTION
Apparently if you use dictionary serialization to get a string identifier, you may get different results for identical dictionaries 😒 